### PR TITLE
Add refresh and error handling to dependency graph

### DIFF
--- a/src/components/dependency-diagram.tsx
+++ b/src/components/dependency-diagram.tsx
@@ -33,6 +33,7 @@ interface DepDiagramProps {
   isDiagramExpanded?: boolean;
   isNodeClicked?: boolean;
   isFixPlanLoading: boolean;
+  error: string;
   onNodeClick?: (g: GraphNode) => void;
   setIsLoading?: (loading: boolean) => void;
   setIsMobile?: (isMobile: boolean) => void;
@@ -52,6 +53,7 @@ const DepDiagram = ({
   windowSize,
   isDiagramExpanded,
   isNodeClicked,
+  error,
   onNodeClick,
   setIsDiagramExpanded,
 }: DepDiagramProps) => {
@@ -748,11 +750,11 @@ const DepDiagram = ({
               ref={svgRef}
               scale={scale}
               className={cn(
-                "border-1 border-accent rounded-xl bg-black/50",
+                "border-1 border-accent rounded-xl bg-black/50 flex h-full w-full",
                 isDragging ? "cursor-grabbing" : "cursor-grab"
               )}
             ></svg>
-            {!isLoading && (
+            {!isLoading && !error && (
               <div>
                 <div className="absolute bottom-16 right-4 flex flex-col items-center justify-center gap-2">
                   <Tooltip>

--- a/src/components/dependency-sidebar/dependency-sidebar.tsx
+++ b/src/components/dependency-sidebar/dependency-sidebar.tsx
@@ -41,6 +41,7 @@ const DependencyDetailsCard = (props: DependencyDetailsProps) => {
     dependencies,
     onClose,
     isSidebarExpanded,
+    isDiagramExpanded,
     setIsSidebarExpanded,
     isMobile,
   } = props;
@@ -255,7 +256,7 @@ const DependencyDetailsCard = (props: DependencyDetailsProps) => {
             : "w-[35%] p-1 h-[calc(100vh-4rem)] pr-1"
           : isMobile
             ? "w-full p-1 top-1/3 pr-1"
-            : "top-[260px] z-10 p-1 pr-1"
+            : isDiagramExpanded ? "top-1/4" : "top-[260px]" ,"z-10 p-1 pr-1"
       )}
     >
       <Card

--- a/src/components/floating-ai-form.tsx
+++ b/src/components/floating-ai-form.tsx
@@ -6,6 +6,7 @@ import { useTextSelection } from "@/providers/text-selection-provider";
 import { LoaderCircle } from "lucide-react";
 import Image from "next/image";
 import React, { useState, useRef, useEffect } from "react";
+import toast from "react-hot-toast";
 
 const FloatingAiForm = () => {
   const { selectedText, setSelectedText, mousePosition, selectedDependency } =
@@ -189,10 +190,10 @@ const FloatingAiForm = () => {
       setError("");
       setPrompt("");
     } catch (err) {
-      // console.error("Error submitting prompt:", err);
       setError("Failed to submit prompt");
+      toast.error("Failed to submit prompt. Please try again later.");
       return;
-    } finally {
+    } finally{
       setLoading(false);
     }
     if (window.getSelection) {
@@ -283,16 +284,21 @@ const FloatingAiForm = () => {
               autoFocus
             />
             <button
+              disabled={loading || !prompt.trim()}
               type="submit"
-              className="flex flex-row items-center border-1 border-accent justify-center bg-accent-foreground rounded w-[20%] transition cursor-pointer"
+              className={cn(
+                "flex flex-row items-center border-1 border-accent justify-center bg-accent-foreground rounded w-[20%] transition cursor-pointer",
+                (!prompt.trim()) && "opacity-50 cursor-not-allowed"
+              )}
             >
               {loading ? (
                 <LoaderCircle
-                  className="animate-spin p-4 "
+                  className="animate-spin text-white my-3"
                   size={24}
                   strokeWidth={3}
                 />
-              ) : (
+              )
+               : (
                 <Image
                   src="genaibutton.svg"
                   alt="Generate Fix Plan"

--- a/src/components/topheadergithub.tsx
+++ b/src/components/topheadergithub.tsx
@@ -27,7 +27,7 @@ interface TopHeaderProps {
   setError: (error: string) => void;
   setDependencies: (dependencies: {
     [technology: string]: Dependency[];
-  }) => void;    
+  }) => void;
   setGraphData: (graphData: EcosystemGraphMap) => void;
   setLoading: (loading: boolean) => void;
   setIsFileHeaderOpen: (open: boolean) => void;
@@ -38,6 +38,7 @@ interface TopHeaderProps {
   setSelectedBranch: (branch: string | null) => void;
   setBranchError: (error: string) => void;
   handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRefresh: () => void;
 }
 
 const TopHeaderGithub = (props: TopHeaderProps) => {
@@ -59,6 +60,7 @@ const TopHeaderGithub = (props: TopHeaderProps) => {
     setSelectedBranch,
     setBranchError,
     handleInputChange,
+    onRefresh,
   } = props;
 
   const router = Router.useRouter();
@@ -74,6 +76,7 @@ const TopHeaderGithub = (props: TopHeaderProps) => {
     console.log("Sanitized Repo:", sanitizedRepo);
 
     if (!branches || branches.length === 0) {
+      console.log("No branches available to select");
       return;
     }
 
@@ -81,16 +84,23 @@ const TopHeaderGithub = (props: TopHeaderProps) => {
     setIsNodeClicked(false);
     setIsSidebarExpanded(false);
     setBranchError("");
-    resetGraphSvg();
 
-    // Redirect to the new URL with the selected branch
-    router.push(
-      `/analyse?username=${encodeURIComponent(
-        sanitizedUsername
-      )}&repo=${encodeURIComponent(
-        sanitizedRepo
-      )}${`&branch=${encodeURIComponent(selectedBranch!)}`}`
-    );
+    // Check if we're on the same page with same parameters
+    const currentUrl = window.location.href;
+    const newUrl = `/analyse?username=${encodeURIComponent(
+      sanitizedUsername
+    )}&repo=${encodeURIComponent(
+      sanitizedRepo
+    )}&branch=${encodeURIComponent(selectedBranch!)}`;
+    
+    if (currentUrl.includes(newUrl.slice(1))) { // Remove leading slash for includes check
+      // Same URL - trigger refresh instead of navigation
+      console.log("Same URL detected, triggering refresh");
+      onRefresh?.();
+    } else {
+      // Different URL - navigate normally
+      router.push(newUrl);
+    }
   };
 
   return (
@@ -128,7 +138,7 @@ const TopHeaderGithub = (props: TopHeaderProps) => {
             />
           </div>
           <Button
-            className="sm:h-13 sm:w-15 bg-muted-foreground disabled:bg-muted-foreground disabled:opacity-80 hover:bg-input text-sm"
+            className="sm:h-13 sm:w-15 bg-muted-foreground disabled:bg-muted-foreground disabled:opacity-80 hover:bg-input text-sm cursor-pointer"
             type="submit"
             disabled={
               isLoading || !inputUrl || !branches.length || loadingBranches

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -24,6 +24,7 @@ export type DependencyGroups = Record<string, Dependency[]>;
 export interface ManifestFileContentsApiResponse {
   dependencies: DependencyGroups;
   vulnerabilities: Vulnerability[];
+  error?: string;
 }
 
 export enum Relation {


### PR DESCRIPTION
Introduces a refresh mechanism for the dependency graph and improves error handling throughout the analyse page and related components. The TopHeaderGithub now triggers a graph refresh if the branch selection does not change the URL, and error states are propagated to the diagram and sidebar. The useGraph hook is refactored to support refresh triggers and to handle API errors more robustly.