### PR TITLE
Update dependency types and langgraph version

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "@google/generative-ai": "^0.24.1",
     "@langchain/core": "^0.3.72",
     "@langchain/google-genai": "^0.2.16",
-    "@langchain/langgraph": "^0.4.6",
+    "@langchain/langgraph": "^0.4.9",
     "ae-cvss-calculator": "^1.0.8",
     "axios": "^1.10.0",
     "cors": "^2.8.5",

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -19,6 +19,7 @@ import {
   inlineAiRateLimiter,
   fixPlanRateLimiter,
 } from "./utils/rate_limits";
+import { DependencyApiResponse } from "./constants/constants";
 
 // Load environment variables
 dotenv.config();
@@ -93,7 +94,16 @@ app.post("/analyseDependencies", analysisRateLimiter, (req: Request, res: Respon
       branch,
     });
 
-    let cachedData: any[] = [];
+    let cachedData: Array<{
+      uuid: string;
+      username: string;
+      repo: string;
+      branch: string;
+      branches: string[];
+      data: DependencyApiResponse | null;
+      created_at: Date;
+    }> = [];
+
     try {
       cachedData = await getCachedAnalysis(username, repo, branch);
 

--- a/backend/service/analysis_service.ts
+++ b/backend/service/analysis_service.ts
@@ -18,6 +18,7 @@ import {
   FileDetails,
   Branch,
   manifestFiles,
+  MavenDependency,
 } from "../constants/constants";
 
 const GITHUB_API_BASE_URL = "https://api.github.com";
@@ -370,7 +371,10 @@ class AnalysisService {
     if (manifestFiles["Pub"]) {
       for (const fileContent of manifestFiles["Pub"]) {
         try {
-          const pubspecYaml = yaml.load(fileContent.content) as any;
+          const pubspecYaml = yaml.load(fileContent.content) as {
+            dependencies?: Record<string, string>;
+            dev_dependencies?: Record<string, string>;
+          };
 
           const processDeps = (deps: Record<string, string>) => {
             for (const [name, version] of Object.entries(deps)) {
@@ -419,7 +423,7 @@ class AnalysisService {
           const dependencies =
             result?.project?.dependencies?.[0]?.dependency || [];
 
-          dependencies.forEach((dep: any) => {
+          dependencies.forEach((dep: MavenDependency) => {
             let version = dep.version?.[0] || "unknown";
             if (version.startsWith("${") && version.endsWith("}")) {
               const propName = version.slice(2, -1);
@@ -859,7 +863,7 @@ class AnalysisService {
             dep.transitiveDependencies = transitiveDependencies;
             console.log(dep.name);
             console.dir(transitiveDependencies, { depth: null });
-          } catch (error) {
+          } catch {
             depsDevErr.push({
               name: dep.name,
               version: dep.version,


### PR DESCRIPTION
Refined type definitions for cached analysis data and Maven dependencies to improve type safety. Updated @langchain/langgraph to version 0.4.9 in package.json.