### PR TITLE
fix: use Node 24 for npm Trusted Publishers

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org/"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avrl/gitdepsec",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI tool for analyzing dependency vulnerabilities in your projects",
   "keywords": [
     "security",


### PR DESCRIPTION
Per https://www.thecandidstartup.org/2026/01/26/bootstrapping-npm-provenance-github-actions.html - Trusted Publishing requires npm 11.5.1+ which comes with Node 24.x