### PR TITLE
Add per-repo branch cache & improve branch sync

### DIFF
--- a/src/app/[username]/[repo]/page.tsx
+++ b/src/app/[username]/[repo]/page.tsx
@@ -61,11 +61,13 @@ const Page = () => {
     useUIState();
   const { selectedNode, setSelectedNode, resetDiagramState } = useDiagramState();
   const { globalFixPlan, ecosystemFixPlans } = useFixPlanData();
-  const { defaultBranch } = useRepoState();
+  const { defaultBranch, selectedBranch, repoBranchCache } = useRepoState();
 
-  // Use defaultBranch from store when URL param is null
-  // Convert null to undefined to match hook parameter types
-  const branch = branchParam || defaultBranch || "";
+  const repoKey = `${username}/${repo}`;
+  const repoCache = repoBranchCache[repoKey];
+  const activeSelectedBranch = repoCache?.selectedBranch ?? selectedBranch;
+  const activeDefaultBranch = repoCache?.defaultBranch ?? defaultBranch;
+  const branch = branchParam || activeSelectedBranch || activeDefaultBranch || "";
 
   // Custom hooks
   const { generateFixPlan } = useFixPlanGeneration({ username, repo, branch });
@@ -75,7 +77,7 @@ const Page = () => {
     username,
     repo,
   });
-  useBranchSync({ branchParam: branch });
+  useBranchSync({ branchParam, repoKey });
   useGraph(username, repo, branch, file, forceRefresh);
   useRepoData(inputUrl);
   const [selectedEcosystem, setSelectedEcosystem] = useState<string | undefined>(

--- a/src/components/dependency-list.tsx
+++ b/src/components/dependency-list.tsx
@@ -67,7 +67,7 @@ export function AppSidebar({ dependencies, isLoading, ...props }: AppSidebarProp
         </div>
       </SidebarHeader>
       <SidebarContent className="rounded-b-lg">
-        <Command className="p-2 border-t-1 border-accent ">
+        <Command className="p-2 border-t border-accent ">
           <CommandInput
             placeholder="Select Dependency..."
             className="h-full"

--- a/src/components/main-content.tsx
+++ b/src/components/main-content.tsx
@@ -9,13 +9,13 @@ import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import { useRepoState, useErrorState, useFileState } from "@/store/app-store";
 import { store } from "@/store/app-store";
-import { useRepoData } from "@/hooks/useRepoData";
+import { useRepoData } from "../hooks/useRepoData";
 import useFileUpload from "@/hooks/useFileUpload";
 import { AlertTriangle, Search, RotateCcw } from "lucide-react";
 import { cn, getRepoKeyFromUrl } from "@/lib/utils";
 
 const MainContent = () => {
-  const { branches, selectedBranch, loadingBranches, loadedRepoKey } = useRepoState();
+  const { branches, selectedBranch, loadingBranches, repoBranchCache } = useRepoState();
 
   const { branchError, setBranchError } = useErrorState();
   const { inputFile: file, setInputFile: setFile } = useFileUpload();
@@ -34,8 +34,8 @@ const MainContent = () => {
   }, [inputUrl]);
 
   const shouldShowBranches = useMemo(() => {
-    return currentRepoKey === loadedRepoKey;
-  }, [currentRepoKey, loadedRepoKey]);
+    return Boolean(currentRepoKey && repoBranchCache[currentRepoKey]);
+  }, [currentRepoKey, repoBranchCache]);
 
   // Debounce the URL input
   useEffect(() => {
@@ -73,9 +73,9 @@ const MainContent = () => {
     }
 
     //url audit
-    if (debouncedUrl && !file && loadedRepoKey) {
+    if (debouncedUrl && !file && currentRepoKey) {
       const branchParam = selectedBranch ? `?branch=${encodeURIComponent(selectedBranch)}` : "";
-      router.push(`/${loadedRepoKey}${branchParam}`);
+      router.push(`/${currentRepoKey}${branchParam}`);
     }
   };
 

--- a/src/components/top-headers/top-header-github.tsx
+++ b/src/components/top-headers/top-header-github.tsx
@@ -114,14 +114,14 @@ const TopHeaderGithub = (props: TopHeaderProps) => {
           <SaveAuditHistory data={result} addButtonRef={addButtonRef} />
           <HeaderToggle from="github" setIsFileHeaderOpen={setFileHeaderOpen} />
           <Input
-            className="sm:w-[65%] h-14 border"
+            className="sm:w-[65%] min-w-0 h-14 border"
             placeholder="https://github.com/username/repo"
             value={inputUrl}
             onChange={handleInputChange}
             aria-label="GitHub repository URL"
           />
-          <div className="sm:w-[35%] h-14">
-            <Dropdown className="shadow-none border-input border text-sm px-3 overflow-x-auto" />
+          <div className="sm:w-[35%] min-w-0 h-14">
+            <Dropdown className="w-full min-w-0 shadow-none border-input border text-sm px-3" />
           </div>
           <ButtonGroup className="sm:flex-row" role="group" aria-label="Repository actions">
             <Tooltip>

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Check, ChevronsUpDown, Loader } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -16,6 +16,7 @@ import { useErrorState, useRepoState } from "@/store/app-store";
 
 interface DropdownProps {
   className?: string;
+  contentClassName?: string;
   isBranchDropdown?: boolean;
   ecosystems?: string[];
   selectedEcosystem?: string;
@@ -25,6 +26,7 @@ interface DropdownProps {
 
 export function Dropdown({
   className,
+  contentClassName,
   isBranchDropdown = true,
   ecosystems = [],
   selectedEcosystem,
@@ -32,31 +34,30 @@ export function Dropdown({
   shouldShowBranches = true,
 }: DropdownProps) {
   const [open, setOpen] = useState(false);
-  const [shouldOpen, setShouldOpen] = useState(false);
   const { branches, selectedBranch, loadingBranches, hasMore, loadNextPage, setSelectedBranch } =
     useRepoState();
   const { setError } = useErrorState();
 
-  // Effect to determine if the dropdown should open
-  useEffect(() => {
-    const items = isBranchDropdown ? branches : ecosystems;
-    if (isBranchDropdown && !shouldShowBranches) {
-      setShouldOpen(false);
-      setOpen(false);
-      return;
-    }
-    if (items.length) {
-      setShouldOpen(true);
-    } else {
-      setShouldOpen(false);
-      setOpen(false);
-    }
-  }, [branches, ecosystems, isBranchDropdown, shouldShowBranches, setError]);
+  const availableItems = isBranchDropdown ? branches : ecosystems;
+  const canOpen = isBranchDropdown ? shouldShowBranches && availableItems.length > 0 : availableItems.length > 0;
+  const isDisabled = isBranchDropdown ? loadingBranches || !canOpen : !canOpen;
+  const isBranchUnavailable = isBranchDropdown && (!branches.length || !shouldShowBranches);
+  const isEcosystemUnavailable = !isBranchDropdown && !ecosystems.length;
+  const triggerLabel = isBranchDropdown
+    ? loadingBranches
+      ? "Loading..."
+      : !shouldShowBranches
+        ? "Select Branch..."
+        : selectedBranch || "Select Branch..."
+    : selectedEcosystem || "Select ecosystem";
 
   const handleOpenChange = (nextOpen: boolean) => {
     // Only block for loading if it's a branch dropdown
-    if (isBranchDropdown && loadingBranches) return;
-    if (nextOpen && !shouldOpen) {
+    if (isBranchDropdown && loadingBranches) {
+      return;
+    }
+
+    if (nextOpen && !canOpen) {
       if (isBranchDropdown) {
         setError("Please enter a valid GitHub repository URL first.");
       }
@@ -70,11 +71,20 @@ export function Dropdown({
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
 
-    // Trigger pagination when user is near the bottom (within 100px)
+    // Trigger pagination when user is near the bottom.
     if (distanceFromBottom <= 500 && hasMore && !loadingBranches) {
-      console.log("Triggering loadNextPage");
       loadNextPage();
     }
+  };
+
+  const handleBranchSelect = (value: string) => {
+    setSelectedBranch(value);
+    setOpen(false);
+  };
+
+  const handleEcosystemSelect = (value: string) => {
+    onEcosystemChange?.(value);
+    setOpen(false);
   };
 
   return (
@@ -85,29 +95,29 @@ export function Dropdown({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          disabled={isBranchDropdown ? loadingBranches || !shouldOpen : !shouldOpen}
+          disabled={isDisabled}
           className={cn(
-            "sm:h-14 text-md w-full text-input justify-between overflow-y-hidden overflow-x-scroll scrollbar-background-hidden border-[3px] border-black px-3 sm:px-4 transition-transform hover:text-secondary-foreground hover:bg-gray-300 max-sm:w-full group",
-            isBranchDropdown && (!branches || branches.length === 0 || !shouldShowBranches)
-              ? "opacity-60 cursor-not-allowed"
-              : "",
-            !isBranchDropdown && !ecosystems.length ? "opacity-60 cursor-not-allowed" : "",
+            "sm:h-14 min-w-0 text-md w-full text-input justify-between overflow-hidden border-[3px] border-black px-3 sm:px-4 transition-transform hover:text-secondary-foreground hover:bg-gray-300 max-sm:w-full group",
+            isBranchUnavailable ? "opacity-60 cursor-not-allowed" : "",
+            isEcosystemUnavailable ? "opacity-60 cursor-not-allowed" : "",
             className,
           )}
         >
-          {isBranchDropdown
-            ? loadingBranches
-              ? "Loading branches..."
-              : !shouldShowBranches
-                ? "Select Branch..."
-                : selectedBranch || "Select Branch..."
-            : selectedEcosystem || "Select ecosystem"}
+          <span className="min-w-0 flex-1 truncate text-left">
+            {triggerLabel}
+          </span>
           <ChevronsUpDown className="opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className={cn("p-0 border-black border-[3px]", className)}>
-        <Command className="max-h-100 rounded-md">
-          {!ecosystems && (
+      <PopoverContent
+        className={cn(
+          "p-0 border-black border-[3px] w-(--radix-popover-trigger-width) max-w-(--radix-popover-trigger-width)! overflow-hidden",
+          contentClassName,
+          className
+        )}
+      >
+        <Command className="max-h-100 rounded-md overflow-hidden w-full">
+          {isBranchDropdown && (
             <CommandInput
               placeholder={isBranchDropdown ? "Search Branch..." : "Search Ecosystem..."}
               className="h-9"
@@ -122,15 +132,12 @@ export function Dropdown({
               !branches.length && !loadingBranches ? (
                 <CommandEmpty>No branch found</CommandEmpty>
               ) : (
-                <CommandGroup className="">
+                <CommandGroup>
                   {branches.map((branch) => (
                     <CommandItem
                       key={branch}
                       value={branch}
-                      onSelect={(value: string) => {
-                        setSelectedBranch(value);
-                        setOpen(false);
-                      }}
+                      onSelect={handleBranchSelect}
                       className="whitespace-normal break-all cursor-pointer"
                     >
                       {branch}
@@ -144,49 +151,44 @@ export function Dropdown({
                   ))}
                   {/* Loading indicator for pagination */}
                   {loadingBranches && branches.length > 0 && (
-                    <CommandItem disabled className="justify-center">
-                      <div className="flex items-center gap-2">
-                        <Loader className="h-4 w-4 animate-spin" />
-                      </div>
+                    <CommandItem disabled className="justify-center p-0 m-0">
+                      <Loader className="h-4 w-4 animate-spin" />
                     </CommandItem>
                   )}
                 </CommandGroup>
               )
             ) : // Ecosystem dropdown mode
-            !ecosystems.length ? (
-              <CommandEmpty>No ecosystem found</CommandEmpty>
-            ) : (
-              <CommandGroup className="m-2">
-                {ecosystems.map((ecosystem) => (
-                  <CommandItem
-                    key={ecosystem}
-                    value={ecosystem}
-                    onSelect={(value: string) => {
-                      onEcosystemChange?.(value);
-                      setOpen(false);
-                    }}
-                    className="whitespace-normal break-all cursor-pointer"
-                  >
-                    {ecosystem}
-                    <Check
-                      className={cn(
-                        "ml-auto",
-                        selectedEcosystem === ecosystem ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )}
+              !ecosystems.length ? (
+                <CommandEmpty>No ecosystem found</CommandEmpty>
+              ) : (
+                <CommandGroup className="m-2">
+                  {ecosystems.map((ecosystem) => (
+                    <CommandItem
+                      key={ecosystem}
+                      value={ecosystem}
+                      onSelect={handleEcosystemSelect}
+                      className="whitespace-normal break-all cursor-pointer"
+                    >
+                      {ecosystem}
+                      <Check
+                        className={cn(
+                          "ml-auto",
+                          selectedEcosystem === ecosystem ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
           </CommandList>
           {isBranchDropdown && (
             <div>
               {!hasMore && branches.length > 0 ? (
-                <div className="p-2 text-center text-xs text-accent border-t">
+                <div className="p-2 text-center text-xs text-accent border-t truncate">
                   All {branches.length} branches loaded
                 </div>
               ) : (
-                <div className="p-2 text-center text-xs text-accent border-t">
+                <div className="p-2 text-center text-xs text-accent border-t truncate">
                   Scroll to load more branches...
                 </div>
               )}

--- a/src/hooks/useBranchSync.ts
+++ b/src/hooks/useBranchSync.ts
@@ -2,35 +2,65 @@ import { useEffect, useRef } from "react";
 import { useRepoState } from "@/store/app-store";
 
 interface UseBranchSyncProps {
-  branchParam: string;
+  branchParam: string | null;
+  repoKey?: string;
 }
 
-/**
- * Synchronizes the selected branch in the store with the URL parameter.
- * - If URL has a valid branch param, selects it
- * - If no branch param, auto-selects the first available branch (once)
- */
-export const useBranchSync = ({ branchParam }: UseBranchSyncProps) => {
-  const { branches, setSelectedBranch } = useRepoState();
-  const hasInitialized = useRef(false);
+export const useBranchSync = ({ branchParam, repoKey }: UseBranchSyncProps) => {
+  const { branches, selectedBranch, setSelectedBranch, repoBranchCache } = useRepoState();
+  const hasInitializedRef = useRef(false);
+  const lastUrlBranchRef = useRef<string | null>(null);
+
+  const syncBranchIfNeeded = (nextBranch: string | null) => {
+    if (!nextBranch || !branches.includes(nextBranch) || selectedBranch === nextBranch) {
+      return;
+    }
+    setSelectedBranch(nextBranch);
+  };
+
+  useEffect(() => {
+    hasInitializedRef.current = false;
+    lastUrlBranchRef.current = null;
+  }, [repoKey]);
 
   useEffect(() => {
     if (branches.length === 0) return;
 
-    // Case 1: URL has a branch parameter - sync to it if valid
     if (branchParam && branches.includes(branchParam)) {
-      setSelectedBranch(branchParam);
-      hasInitialized.current = true;
+      const shouldSyncFromUrl =
+        !hasInitializedRef.current || lastUrlBranchRef.current !== branchParam;
+
+      if (shouldSyncFromUrl) {
+        syncBranchIfNeeded(branchParam);
+      }
+
+      hasInitializedRef.current = true;
+      lastUrlBranchRef.current = branchParam;
       return;
     }
 
-    // Case 2: No URL param AND first time - auto-select first branch
-    if (!branchParam && !hasInitialized.current) {
-      setSelectedBranch(branches[0]);
-      hasInitialized.current = true;
+    if (selectedBranch && branches.includes(selectedBranch)) {
+      hasInitializedRef.current = true;
       return;
     }
-  }, [branchParam, branches, setSelectedBranch]);
+
+    if (!hasInitializedRef.current && repoKey) {
+      const cachedEntry = repoBranchCache[repoKey];
+      const cachedBranch = cachedEntry?.selectedBranch || cachedEntry?.defaultBranch;
+
+      if (cachedBranch && branches.includes(cachedBranch)) {
+        syncBranchIfNeeded(cachedBranch);
+        hasInitializedRef.current = true;
+        return;
+      }
+    }
+
+    if (!hasInitializedRef.current && branches[0]) {
+      syncBranchIfNeeded(branches[0]);
+      hasInitializedRef.current = true;
+      return;
+    }
+  }, [branchParam, branches, selectedBranch, setSelectedBranch, repoBranchCache, repoKey]);
 };
 
 export default useBranchSync;

--- a/src/hooks/useGraph.ts
+++ b/src/hooks/useGraph.ts
@@ -12,7 +12,7 @@ import {
   Vulnerability,
 } from "@/constants/model";
 import { CACHE_TTL, MANIFEST_FILES } from "@/constants/constants";
-import { store, useErrorState, useGraphState, useRepoState } from "@/store/app-store";
+import { store, useErrorState, useGraphState } from "@/store/app-store";
 import toast from "react-hot-toast";
 
 export const useGraph = (
@@ -25,7 +25,6 @@ export const useGraph = (
   const { setError, setManifestError } = useErrorState();
   const { dependencies, setDependencies, setManifestData, setGraphData, setLoading } =
     useGraphState();
-  const { setBranches } = useRepoState();
 
   const fetchDependencies = useCallback(
     async (
@@ -255,7 +254,6 @@ export const useGraph = (
         console.log("Cache hit - using fresh cached data");
         setGraphData(matchingItem.graphData, currentRepoKey);
         setDependencies(matchingItem.dependencies);
-        setBranches(matchingItem.branches || []);
         setLoading(false);
         return true;
       }
@@ -265,7 +263,6 @@ export const useGraph = (
     branch,
     forceRefresh,
     repo,
-    setBranches,
     setDependencies,
     setGraphData,
     setLoading,

--- a/src/hooks/useHistoryNavigation.ts
+++ b/src/hooks/useHistoryNavigation.ts
@@ -1,25 +1,15 @@
 import { useRouter } from "next/navigation";
 import { HistoryItem } from "@/constants/model";
-import { useRepoState } from "@/store/app-store";
 import { useCallback } from "react";
 
 export const useHistoryNavigation = () => {
   const router = useRouter();
-  const { loadedRepoKey, setLoadedRepoKey } = useRepoState();
 
   const navigateToHistory = useCallback(
     (hist: HistoryItem) => {
-      // const githubUrl = `https://github.com/${hist.username}/${hist.repo}`;
-      const newRepoKey = `${hist.username}/${hist.repo}`;
-
-      // Only reset loadedRepoKey if navigating to a different repo
-      if (loadedRepoKey !== newRepoKey) {
-        setLoadedRepoKey(null);
-      }
-      // setCurrentUrl(githubUrl);
       router.push(`/${hist.username}/${hist.repo}?branch=${hist.branch}`);
     },
-    [router, loadedRepoKey, setLoadedRepoKey],
+    [router],
   );
 
   return { navigateToHistory };

--- a/src/hooks/useRepoData.ts
+++ b/src/hooks/useRepoData.ts
@@ -1,105 +1,236 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import { getRepoBranches } from "@/lib/api";
 import { verifyUrl, getRepoKeyFromUrl } from "@/lib/utils";
 import { useErrorState, useRepoState, store } from "@/store/app-store";
 import { HistoryItem } from "@/constants/model";
 import { DEFAULT_BRANCH_NAMES } from "@/constants/constants";
 
-export const useRepoData = (url: string | null) => {
-  const pageSize = 100;
-  const { page, loadedRepoKey, setLoadingBranches, resetRepoState } = useRepoState();
+const PAGE_SIZE = 100;
 
+export const useRepoData = (url: string | null) => {
+  const { page, setLoadingBranches, resetRepoState, upsertRepoBranchCache } = useRepoState();
   const { setBranchError } = useErrorState();
+  const latestRequestIdRef = useRef(0);
+
+  const ensureDefaultBranchFirst = (branches: string[], defaultBranch: string | null) => {
+    if (!defaultBranch) return branches;
+    if (!branches.includes(defaultBranch)) return branches;
+
+    return [defaultBranch, ...branches.filter((branch) => branch !== defaultBranch)];
+  };
+
+  const buildBranchList = ({
+    currentPage,
+    currentBranches,
+    fetchedBranches,
+    defaultBranch,
+  }: {
+    currentPage: number;
+    currentBranches: string[];
+    fetchedBranches: string[];
+    defaultBranch?: string | null;
+  }) => {
+    if (currentPage > 1) {
+      return Array.from(new Set([...currentBranches, ...fetchedBranches]));
+    }
+
+    if (defaultBranch && !fetchedBranches.includes(defaultBranch)) {
+      return [defaultBranch, ...fetchedBranches];
+    }
+
+    return fetchedBranches;
+  };
+
+  const findCachedHistoryItem = (repoKey: string) => {
+    const historyItems = store.getState().savedHistoryItems;
+    const matchingItems = Object.values(historyItems)
+      .flat()
+      .filter((item) => `${item.username}/${item.repo}` === repoKey);
+
+    return (
+      matchingItems.find((item) => DEFAULT_BRANCH_NAMES.includes(item.branch.toLowerCase())) ||
+      matchingItems[0]
+    );
+  };
+
+  const syncBranchState = useCallback(
+    ({
+      repoKey,
+      branches,
+      selectedBranch,
+      defaultBranch,
+      hasMore,
+      totalBranches,
+      currentPage,
+    }: {
+      repoKey: string;
+      branches: string[];
+      selectedBranch: string | null;
+      defaultBranch: string | null;
+      hasMore: boolean;
+      totalBranches: number;
+      currentPage: number;
+    }) => {
+      const orderedBranches = ensureDefaultBranchFirst(branches, defaultBranch);
+
+      store.setState({
+        branches: orderedBranches,
+        selectedBranch,
+        defaultBranch,
+        loadedRepoKey: repoKey,
+        loadingBranches: false,
+        branchError: "",
+        hasMore,
+        totalBranches,
+        page: currentPage,
+      });
+
+      upsertRepoBranchCache(repoKey, {
+        branches: orderedBranches,
+        selectedBranch,
+        defaultBranch,
+        hasMore,
+        totalBranches,
+        page: currentPage,
+      });
+    },
+    [upsertRepoBranchCache],
+  );
+
+  const hydrateFromCache = useCallback(
+    (
+      repoKey: string,
+      branches: string[],
+      selectedBranch: string | null | undefined,
+      defaultBranch: string | null | undefined,
+      hasMore: boolean,
+    ) => {
+      const normalizedDefaultBranch =
+        defaultBranch ??
+        branches.find((branch) => DEFAULT_BRANCH_NAMES.includes(branch.toLowerCase())) ??
+        null;
+
+      syncBranchState({
+        repoKey,
+        branches,
+        selectedBranch: selectedBranch ?? normalizedDefaultBranch,
+        defaultBranch: normalizedDefaultBranch,
+        hasMore,
+        totalBranches: branches.length,
+        currentPage: 1,
+      });
+    },
+    [syncBranchState],
+  );
 
   const updateCacheBranches = useCallback(
     (cachedItem: HistoryItem | undefined, branchList: string[]) => {
       if (!cachedItem) return;
 
       const historyItems = store.getState().savedHistoryItems;
-
-      const dateKey = Object.keys(historyItems).find((dateKey) =>
-        historyItems[dateKey].some(
+      const dateKey = Object.keys(historyItems).find((key) =>
+        historyItems[key].some(
           (item) => item.username === cachedItem.username && item.repo === cachedItem.repo,
         ),
       );
 
-      if (dateKey) {
-        const itemIndex = historyItems[dateKey].findIndex(
-          (item) => item.username === cachedItem.username && item.repo === cachedItem.repo,
-        );
+      if (!dateKey) return;
 
-        if (itemIndex !== -1) {
-          store.setState((prev) => ({
-            savedHistoryItems: {
-              ...prev.savedHistoryItems,
-              [dateKey]: prev.savedHistoryItems[dateKey].map((item, idx) =>
-                idx === itemIndex ? { ...item, branches: branchList } : item,
-              ),
-            },
-          }));
-        }
-      }
+      const itemIndex = historyItems[dateKey].findIndex(
+        (item) => item.username === cachedItem.username && item.repo === cachedItem.repo,
+      );
+
+      if (itemIndex === -1) return;
+
+      store.setState((prev) => ({
+        savedHistoryItems: {
+          ...prev.savedHistoryItems,
+          [dateKey]: prev.savedHistoryItems[dateKey].map((item, idx) =>
+            idx === itemIndex ? { ...item, branches: branchList } : item,
+          ),
+        },
+      }));
     },
     [],
   );
 
   const fetchBranches = useCallback(
-    async (graphRepoKey: string) => {
+    async (repoKey: string, forcePage?: number) => {
       if (!url) return;
+      const requestId = ++latestRequestIdRef.current;
+      const isStaleRequest = () => requestId !== latestRequestIdRef.current;
 
-      const result = verifyUrl(url, setBranchError);
-      if (!result) {
-        setLoadingBranches(false);
-        return;
-      }
-      const { sanitizedUsername, sanitizedRepo } = result;
-
-      const historyItems = store.getState().savedHistoryItems;
-
-      /**
-       * Always find the cached item so we can update it later
-       * Match by repo only (not branch) since branches list is same for any username/repo key
-       * Prioritize finding an item with a default branch name for better UX
-       */
-      const matchingItems = Object.values(historyItems)
-        .flat()
-        .filter((item) => {
-          const itemRepoKey = `${item.username}/${item.repo}`;
-          return itemRepoKey === `${sanitizedUsername}/${sanitizedRepo}`;
-        });
-
-      // Try to find one with a common default branch name first
-      const cachedItem =
-        matchingItems.find((item) => DEFAULT_BRANCH_NAMES.includes(item.branch.toLowerCase())) ||
-        matchingItems[0]; // Fall back to first match if no default found
-
-      // Only use cache for page 1 - pagination should always fetch from API
-      if (page === 1 && cachedItem && cachedItem.branches && cachedItem.branches.length > 0) {
-        const hasFullPage = cachedItem.branches.length >= pageSize;
-        store.setState({
-          branches: cachedItem.branches,
-          selectedBranch: cachedItem.branch || null,
-          defaultBranch: cachedItem.branch || null,
-          loadedRepoKey: graphRepoKey,
-          loadingBranches: false,
-          branchError: "",
-          hasMore: hasFullPage,
-          totalBranches: cachedItem.branches.length,
-        });
+      const context = verifyUrl(url, setBranchError);
+      if (!context) {
+        if (!isStaleRequest()) {
+          setLoadingBranches(false);
+        }
         return;
       }
 
-      // If not in cache (or page > 1), fetch from API
-      setLoadingBranches(true);
+      const { sanitizedUsername, sanitizedRepo } = context;
+      const currentPage = forcePage ?? store.getState().repoBranchCache[repoKey]?.page ?? 1;
+      const isFirstPage = currentPage === 1;
+      const repoCacheEntry = store.getState().repoBranchCache[repoKey];
+      const cachedHistoryItem = findCachedHistoryItem(repoKey);
 
-      const branchesResponse = await getRepoBranches(
-        sanitizedUsername,
-        sanitizedRepo,
-        page,
-        pageSize,
-      );
+      const hydrateCachedBranches = () => {
+        if (!isFirstPage) return false;
+
+        if (repoCacheEntry?.branches?.length) {
+          if (isStaleRequest()) return true;
+          hydrateFromCache(
+            repoKey,
+            repoCacheEntry.branches,
+            repoCacheEntry.selectedBranch,
+            repoCacheEntry.defaultBranch,
+            repoCacheEntry.hasMore,
+          );
+          return true;
+        }
+
+        if (cachedHistoryItem?.branches?.length) {
+          if (isStaleRequest()) return true;
+          hydrateFromCache(
+            repoKey,
+            cachedHistoryItem.branches,
+            cachedHistoryItem.branch,
+            null,
+            cachedHistoryItem.branches.length >= PAGE_SIZE,
+          );
+          return true;
+        }
+
+        return false;
+      };
+
+      if (hydrateCachedBranches()) {
+        return;
+      }
+
+      if (!isStaleRequest()) {
+        setLoadingBranches(true);
+      }
+
+      let branchesResponse;
+      try {
+        branchesResponse = await getRepoBranches(
+          sanitizedUsername,
+          sanitizedRepo,
+          currentPage,
+          PAGE_SIZE,
+        );
+      } catch {
+        if (!isStaleRequest()) {
+          setBranchError("Failed to fetch branches. Please try again.");
+          setLoadingBranches(false);
+        }
+        return;
+      }
+
+      if (isStaleRequest()) return;
 
       if (branchesResponse.error) {
         setBranchError(branchesResponse.error);
@@ -107,46 +238,42 @@ export const useRepoData = (url: string | null) => {
         return;
       }
 
-      // For first page, replace branches. For subsequent pages, append them
-      let branchList = [];
-      if (page === 1) {
-        if (
-          branchesResponse.defaultBranch &&
-          !branchesResponse.branches?.includes(branchesResponse.defaultBranch)
-        ) {
-          branchList = [branchesResponse.defaultBranch, ...(branchesResponse.branches || [])];
-        } else {
-          branchList = branchesResponse.branches || [];
-        }
-      } else {
-        const currentBranches = store.getState().branches;
-        const newBranchesToAdd = branchesResponse.branches || [];
-        const uniqueBranches = Array.from(new Set([...currentBranches, ...newBranchesToAdd]));
-        branchList = uniqueBranches;
-      }
+      const fetchedBranches = branchesResponse.branches || [];
+      const currentState = store.getState();
+      const branchList = buildBranchList({
+        currentPage,
+        currentBranches: currentState.branches,
+        fetchedBranches,
+        defaultBranch: branchesResponse.defaultBranch,
+      });
 
-      store.setState({
+      syncBranchState({
+        repoKey,
         branches: branchList,
-        ...(page === 1 && {
-          selectedBranch: branchesResponse.defaultBranch ?? null,
-          defaultBranch: branchesResponse.defaultBranch ?? null,
-          loadedRepoKey: graphRepoKey,
-        }),
+        selectedBranch:
+          isFirstPage ? (branchesResponse.defaultBranch ?? null) : currentState.selectedBranch,
+        defaultBranch:
+          isFirstPage ? (branchesResponse.defaultBranch ?? null) : currentState.defaultBranch,
         hasMore: branchesResponse.hasMore || false,
         totalBranches: branchesResponse.total || 0,
-        loadingBranches: false,
-        branchError: "",
+        currentPage,
       });
-      updateCacheBranches(cachedItem, branchList);
+
+      updateCacheBranches(cachedHistoryItem, branchList);
     },
-    [url, setBranchError, setLoadingBranches, page, resetRepoState, updateCacheBranches],
+    [
+      url,
+      setBranchError,
+      setLoadingBranches,
+      resetRepoState,
+      hydrateFromCache,
+      syncBranchState,
+      updateCacheBranches,
+    ],
   );
 
   useEffect(() => {
-    if (!url) {
-      // resetRepoState();
-      return;
-    }
+    if (!url) return;
 
     const repoKey = getRepoKeyFromUrl(url);
     if (!repoKey) {
@@ -154,18 +281,13 @@ export const useRepoData = (url: string | null) => {
       return;
     }
 
-    const { defaultBranch } = store.getState();
+    const cachedPage = store.getState().repoBranchCache[repoKey]?.page || 1;
+    if (cachedPage > 1) {
+      fetchBranches(repoKey, cachedPage);
+      return;
+    }
 
-    let debounceTimeout: NodeJS.Timeout;
-    // Case 1: Different repo - always fetch branches (from cache or API)
-    // Case 2: Same repo but missing defaultBranch - need to fetch
-    if (loadedRepoKey !== repoKey || (loadedRepoKey === repoKey && !defaultBranch)) {
-      debounceTimeout = setTimeout(() => fetchBranches(repoKey), 400);
-    }
-    // Case 3: Same repo - only fetch if loading next page
-    if (loadedRepoKey === repoKey && page > 1) {
-      fetchBranches(repoKey);
-    }
+    const debounceTimeout = setTimeout(() => fetchBranches(repoKey, 1), 400);
     return () => clearTimeout(debounceTimeout);
-  }, [url, page, loadedRepoKey, fetchBranches, resetRepoState, setBranchError]);
+  }, [url, page, fetchBranches, setBranchError]);
 };

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -52,6 +52,7 @@ export const store = create<AppStore>()(
           hasMore: state.hasMore,
           totalBranches: state.totalBranches,
           currentUrl: state.currentUrl,
+          repoBranchCache: state.repoBranchCache,
           savedHistoryItems: state.savedHistoryItems,
           fixPlansByRepo: state.fixPlansByRepo,
           currentFixPlanRepoKey: state.currentFixPlanRepoKey,
@@ -110,6 +111,7 @@ export const useRepoState = createSelector((s) => ({
   page: s.page,
   currentUrl: s.currentUrl,
   loadedRepoKey: s.loadedRepoKey,
+  repoBranchCache: s.repoBranchCache,
   setBranches: s.setBranches,
   setSelectedBranch: s.setSelectedBranch,
   setDefaultBranch: s.setDefaultBranch,
@@ -119,7 +121,7 @@ export const useRepoState = createSelector((s) => ({
   setTotalBranches: s.setTotalBranches,
   setPage: s.setPage,
   setCurrentUrl: s.setCurrentUrl,
-  setLoadedRepoKey: s.setLoadedRepoKey,
+  upsertRepoBranchCache: s.upsertRepoBranchCache,
   resetRepoState: s.resetRepoState,
 }));
 

--- a/src/store/slices.ts
+++ b/src/store/slices.ts
@@ -17,6 +17,45 @@ import {
 } from "@/constants/model";
 import { deepMergeFixPlanData, hasFixPlanChanged, orderFixPlanData } from "@/lib/fixPlanUtils";
 
+const REPO_BRANCH_CACHE_LIMIT = 10;
+
+const createRepoBranchCacheFallback = (s: RepoState, repoKey: string) => ({
+  branches: s.repoBranchCache[repoKey]?.branches ?? s.branches,
+  selectedBranch: s.repoBranchCache[repoKey]?.selectedBranch ?? s.selectedBranch,
+  defaultBranch: s.repoBranchCache[repoKey]?.defaultBranch ?? s.defaultBranch,
+  hasMore: s.repoBranchCache[repoKey]?.hasMore ?? s.hasMore,
+  totalBranches: s.repoBranchCache[repoKey]?.totalBranches ?? s.totalBranches,
+  page: s.repoBranchCache[repoKey]?.page ?? s.page,
+});
+
+const withBoundedRepoBranchCache = (
+  cache: RepoState["repoBranchCache"],
+  repoKey: string,
+  nextEntry: Partial<RepoState["repoBranchCache"][string]>,
+) => {
+  const { [repoKey]: existing, ...rest } = cache;
+  const mergedEntry = {
+    branches: existing?.branches ?? [],
+    selectedBranch: existing?.selectedBranch ?? null,
+    defaultBranch: existing?.defaultBranch ?? null,
+    hasMore: existing?.hasMore ?? false,
+    totalBranches: existing?.totalBranches ?? 0,
+    page: existing?.page ?? 1,
+    ...nextEntry,
+  };
+
+  const reordered = { ...rest, [repoKey]: mergedEntry };
+  const keys = Object.keys(reordered);
+
+  if (keys.length <= REPO_BRANCH_CACHE_LIMIT) {
+    return reordered;
+  }
+
+  const oldestKey = keys[0];
+  const { [oldestKey]: _, ...bounded } = reordered;
+  return bounded;
+};
+
 export const createRepoSlice: StateCreator<AppStore, [], [], RepoState> = (set) => ({
   branches: [],
   selectedBranch: null,
@@ -27,22 +66,88 @@ export const createRepoSlice: StateCreator<AppStore, [], [], RepoState> = (set) 
   page: 1,
   currentUrl: null,
   loadedRepoKey: null,
-  setBranches: (branches) => set({ branches }),
-  setSelectedBranch: (branch) => set({ selectedBranch: branch }),
-  setDefaultBranch: (branch) => set({ defaultBranch: branch }),
+  repoBranchCache: {},
+  setBranches: (branches) =>
+    set((s) => {
+      const repoKey = s.loadedRepoKey;
+      if (!repoKey) return { branches };
+
+      return {
+        branches,
+        repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, {
+          ...createRepoBranchCacheFallback(s, repoKey),
+          branches,
+        }),
+      };
+    }),
+  setSelectedBranch: (branch) =>
+    set((s) => {
+      const repoKey = s.loadedRepoKey;
+      if (!repoKey) return { selectedBranch: branch };
+
+      return {
+        selectedBranch: branch,
+        repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, {
+          ...createRepoBranchCacheFallback(s, repoKey),
+          selectedBranch: branch,
+        }),
+      };
+    }),
+  setDefaultBranch: (branch) =>
+    set((s) => {
+      const repoKey = s.loadedRepoKey;
+      if (!repoKey) return { defaultBranch: branch };
+
+      return {
+        defaultBranch: branch,
+        repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, {
+          ...createRepoBranchCacheFallback(s, repoKey),
+          defaultBranch: branch,
+        }),
+      };
+    }),
   setLoadingBranches: (loading) => set({ loadingBranches: loading }),
   loadNextPage: () =>
     set((s) => {
       if (s.hasMore && !s.loadingBranches) {
-        return { page: s.page + 1 };
+        const nextPage = s.page + 1;
+        const repoKey = s.loadedRepoKey;
+        if (!repoKey) {
+          return { page: nextPage };
+        }
+
+        return {
+          page: nextPage,
+          repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, {
+            ...createRepoBranchCacheFallback(s, repoKey),
+            page: nextPage,
+          }),
+        };
       }
       return {};
     }),
   setHasMore: (hasMore) => set({ hasMore }),
   setTotalBranches: (total) => set({ totalBranches: total }),
-  setPage: (page) => set({ page }),
+  setPage: (page) =>
+    set((s) => {
+      const repoKey = s.loadedRepoKey;
+      if (!repoKey) {
+        return { page };
+      }
+
+      return {
+        page,
+        repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, {
+          ...createRepoBranchCacheFallback(s, repoKey),
+          page,
+        }),
+      };
+    }),
   setCurrentUrl: (url) => set({ currentUrl: url }),
-  setLoadedRepoKey: (key) => set({ loadedRepoKey: key }),
+  upsertRepoBranchCache: (repoKey, entry) =>
+    set((s) => ({
+      repoBranchCache: withBoundedRepoBranchCache(s.repoBranchCache, repoKey, entry),
+    })),
   resetRepoState: () =>
     set({
       branches: [],

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -16,6 +16,7 @@ export interface RepoState {
   page: number;
   currentUrl: string | null;
   loadedRepoKey: string | null;
+  repoBranchCache: Record<string, RepoBranchCacheEntry>;
   setBranches: (branches: string[]) => void;
   setSelectedBranch: (branch: string | null) => void;
   setDefaultBranch: (branch: string | null) => void;
@@ -25,8 +26,17 @@ export interface RepoState {
   setTotalBranches: (total: number) => void;
   setPage: (page: number) => void;
   setCurrentUrl: (url: string | null) => void;
-  setLoadedRepoKey: (key: string | null) => void;
+  upsertRepoBranchCache: (repoKey: string, entry: Partial<RepoBranchCacheEntry>) => void;
   resetRepoState: () => void;
+}
+
+export interface RepoBranchCacheEntry {
+  branches: string[];
+  selectedBranch: string | null;
+  defaultBranch: string | null;
+  hasMore: boolean;
+  totalBranches: number;
+  page: number;
 }
 
 export interface FileState {


### PR DESCRIPTION
Introduce a repoBranchCache and related logic to persist branch lists, default/selected branch, pagination and metadata per repository. The store gains repoBranchCache, an upsert helper and bounded eviction (limit 10). useRepoData now hydrates from cache, fetches branches with pagination/resilience, ensures default branch ordering, updates cache and history entries, and debounces/avoids stale requests. useBranchSync was enhanced to accept repoKey, respect URL params, cached selection, and avoid unnecessary re-syncs. UI/UX fixes: Dropdown disabled/labels, loading/pagination handling and selection callbacks; MainContent and TopHeader layout/truncation improvements; small style fix in dependency list. Also remove an unused setBranches import in useGraph and simplify history navigation. These changes reduce refetching, fix race conditions, and improve branch selection UX across repos.